### PR TITLE
[codex] Verify changed-files halts on non-src diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,105 +1,26 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-setup: true
-
 orbs:
-  file-changes:
-    commands:
-      halt-if-not-changed:
-        parameters:
-          pattern:
-            type: string
-          diff-filter:
-            type: string
-            default: "d" # without deleted files
-        steps:
-          - checkout
-          - run:
-              name: "Check if files are changed"
-              command: |
-                echo "Fetching base branch..."
-                BASE_BRANCH=$(git ls-remote --symref origin HEAD | grep -oP '(?<=refs/heads/)\S+')
-                BASE_SHA1=$(git ls-remote --symref origin HEAD | tail -n 1 | cut -f 1)
-                echo "Base SHA1: $BASE_SHA1"
-                echo "Base BRANCH: $BASE_BRANCH"
-                echo
+  changed-files: https://raw.githubusercontent.com/f440/change-files-orb/refs/heads/main/orb.yml
 
-                # Since the difference of files is calculated based on the default branch,
-                # the difference cannot be obtained if the PR is created from the default branch.
-                if [ $BASE_BRANCH = $CIRCLE_BRANCH ]; then
-                  echo "Base branch is same as default branch. Regular job will be executed."
-                  exit 0
-                fi
-
-                echo "Changed files:"
-                git diff --name-only --diff-filter=<< parameters.diff-filter >> $BASE_SHA1...$CIRCLE_SHA1 | tee changed.txt
-                echo
-                if [ $? -ne 0 ]; then
-                  echo "Failed to get changed files. Regular job will be executed."
-                  exit 0
-                fi
-
-                echo "Matched files:"
-                cat changed.txt | grep -P -e "<< parameters.pattern >>" | tee matched.txt || true
-                echo
-                if [ ! -s matched.txt ]; then
-                  echo "not matched. skip."
-                  circleci-agent step halt
-                fi
-
-commands:
-  skip-if-npm-dev-dependencies-update:
-    description: "Job halted (irrelevant update: npm devDependencies)"
-    steps:
-      - when:
-          condition:
-            matches:
-              pattern: "^renovate/.*devDependencies-.*"
-              value: << pipeline.git.branch >>
-          steps:
-            - run:
-                name: "Job halted (irrelevant update: npm devDependencies)"
-                command: circleci-agent step halt
-  skip-if-npm-dependencies-update:
-    description: "Job halted (irrelevant update: npm dependencies)"
-    steps:
-      - when:
-          condition:
-            matches:
-              pattern: "^renovate/.*dependencies-.*"
-              value: << pipeline.git.branch >>
-          steps:
-            - run:
-                name: "Job halted (irrelevant update: npm dependencies)"
-                command: circleci-agent step halt
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/configuration-reference/#executor-job
+  verify-src-gating:
     docker:
       - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/configuration-reference/#steps
     steps:
-      - file-changes/halt-if-not-changed:
-          pattern: "src/.*"
+      - checkout
+      - changed-files/check:
+          base-branch: main
+          files: |
+            src/**
+          debug: true
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: Fail if the gate continued
+          command: |
+            echo "changed-files/check continued past the gate"
+            exit 1
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  say-hello-workflow:
+  verify:
     jobs:
-      - say-hello
-      # - path-filtering/filter:
-      #     base-revision: main
-      #     config-path: .circleci/config-x.yml
-      #     mapping: |
-      #       src/x/.* flag-x true
+      - verify-src-gating

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 hi
 aa
 Verification note for changed-files orb halt behavior.
+Rerun trigger after URL orb allow-list update.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 hi
 aa
+Verification note for changed-files orb halt behavior.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ hi
 aa
 Verification note for changed-files orb halt behavior.
 Rerun trigger after URL orb allow-list update.
+Rerun trigger after switching CircleCI auth mode to OAuth.


### PR DESCRIPTION
## What changed
Adds a minimal CircleCI config that uses the `changed-files` URL orb and changes only `README.md`.

## Expected result
The `verify-src-gating` job should halt before the final failing step because no files under `src/**` changed. That means the PR check should finish successfully.

## Validation target
Confirms actual CircleCI halt behavior for non-matching diffs.
